### PR TITLE
Separate request response logging

### DIFF
--- a/http_extensions/.gitignore
+++ b/http_extensions/.gitignore
@@ -1,11 +1,28 @@
-# Files and directories created by pub
-.dart_tool/
-.packages
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
 
-# Conventional directory for build outputs
-build/
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+/out/
 
 # Directory created by dartdoc
 doc/api/
+/http_extensions.iml

--- a/http_extensions/lib/src/buffered_request.dart
+++ b/http_extensions/lib/src/buffered_request.dart
@@ -13,7 +13,7 @@ class BufferedRequest extends BaseRequest {
 
   List<int>? _bytes;
 
-  Future<List<int>?>? _futureBytes;
+  Future<List<int>>? _futureBytes;
 
   @override
   int? get contentLength => base.contentLength;
@@ -49,12 +49,12 @@ class BufferedRequest extends BaseRequest {
   ByteStream finalize() {
     if (_bytes != null) return ByteStream.fromBytes(_bytes!);
     _futureBytes ??= _getBytes();
-    return ByteStream(Stream.fromFuture(_futureBytes as Future<List<int>>));
+    return ByteStream(Stream.fromFuture(_futureBytes!));
   }
 
-  Future<List<int>?> _getBytes() async {
-    final s = await base.finalize();
+  Future<List<int>> _getBytes() async {
+    final s = base.finalize();
     _bytes = await s.toBytes();
-    return _bytes;
+    return _bytes!;
   }
 }

--- a/http_extensions/lib/src/buffered_response.dart
+++ b/http_extensions/lib/src/buffered_response.dart
@@ -8,21 +8,21 @@ class BufferedStreamResponse implements StreamedResponse {
 
   List<int>? _bytes;
 
-  Stream<List<int>?> _getStream() {
+  Stream<List<int>> _getStream() {
     if (_bytes != null) {
-      return Stream.fromIterable([_bytes]);
+      return Stream.fromIterable([_bytes!]);
     }
 
     return Stream.fromFuture(_readBytes());
   }
 
-  Future<List<int>?> _readBytes() async {
+  Future<List<int>> _readBytes() async {
     _bytes = await base.stream.toBytes();
-    return _bytes;
+    return _bytes!;
   }
 
   @override
-  ByteStream get stream => ByteStream(_getStream() as Stream<List<int>>);
+  ByteStream get stream => ByteStream(_getStream());
 
   @override
   int? get contentLength => base.contentLength;

--- a/http_extensions_base_url/.gitignore
+++ b/http_extensions_base_url/.gitignore
@@ -1,11 +1,28 @@
-# Files and directories created by pub
-.dart_tool/
-.packages
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
 
-# Conventional directory for build outputs
-build/
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+/out/
 
 # Directory created by dartdoc
 doc/api/
+/http_extensions_base_url.iml

--- a/http_extensions_cache/.gitignore
+++ b/http_extensions_cache/.gitignore
@@ -1,11 +1,28 @@
-# Files and directories created by pub
-.dart_tool/
-.packages
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
 
-# Conventional directory for build outputs
-build/
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+/out/
 
 # Directory created by dartdoc
 doc/api/
+/http_extensions_cache.iml

--- a/http_extensions_headers/.gitignore
+++ b/http_extensions_headers/.gitignore
@@ -1,11 +1,28 @@
-# Files and directories created by pub
-.dart_tool/
-.packages
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
 
-# Conventional directory for build outputs
-build/
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+/out/
 
 # Directory created by dartdoc
 doc/api/
+/http_extensions_headers.iml

--- a/http_extensions_log/.gitignore
+++ b/http_extensions_log/.gitignore
@@ -1,11 +1,28 @@
-# Files and directories created by pub
-.dart_tool/
-.packages
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
 
-# Conventional directory for build outputs
-build/
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+/out/
 
 # Directory created by dartdoc
 doc/api/
+/http_extensions_log.iml

--- a/http_extensions_log/lib/src/extension.dart
+++ b/http_extensions_log/lib/src/extension.dart
@@ -9,8 +9,7 @@ import 'options.dart';
 class LogExtension extends Extension<LogOptions> {
   final Logger? logger;
 
-  LogExtension({LogOptions defaultOptions = const LogOptions(), this.logger})
-      : super(defaultOptions: defaultOptions);
+  LogExtension({LogOptions defaultOptions = const LogOptions(), this.logger}) : super(defaultOptions: defaultOptions);
 
   void log(String message, LogOptions options) {
     if (logger != null) {
@@ -22,8 +21,7 @@ class LogExtension extends Extension<LogOptions> {
 
   int _id = 0;
 
-  Future<String> _formatRequest(
-      int id, BaseRequest request, LogOptions options) async {
+  Future<String> _formatRequest(int id, BaseRequest request, LogOptions options) async {
     if (request is ExtensionRequest) {
       return _formatRequest(id, request.request, options);
     }
@@ -31,101 +29,91 @@ class LogExtension extends Extension<LogOptions> {
     final requestLog = StringBuffer();
 
     requestLog.writeln('-> REQ($id) [ ${request.method} | ${request.url} ]');
-    if (options.logHeaders) {
-      requestLog
-          .writeln('  * headers: ${request.headers.isEmpty ? 'empty' : ''}');
+    if (options.logRequestHeaders) {
+      requestLog.writeln('  * headers: ${request.headers.isEmpty ? 'empty' : ''}');
       request.headers.forEach((k, v) {
         requestLog.writeln('    * $k: $v');
       });
     }
 
-    if (options.logContent) {
+    if (options.logRequestContent) {
       requestLog.writeln('  * content-length: ${request.contentLength}');
 
-      final bytes = await request.finalize();
+      final bytes = request.finalize();
       final content = await bytes.toBytes();
-      requestLog.writeln(
-          '  * content: ${utf8.decode(content, allowMalformed: true)}');
+      requestLog.writeln('  * content: ${utf8.decode(content, allowMalformed: true)}');
     }
 
     return requestLog.toString();
   }
 
-  Future<String> _formatResponse(
-      int id, StreamedResponse response, LogOptions options) async {
+  Future<String> _formatResponse(int id, StreamedResponse response, LogOptions options) async {
     final requestLog = StringBuffer();
 
-    requestLog.writeln(
-        '<- RES($id) [ ${response.request!.method} | ${response.request!.url}]');
+    requestLog.writeln('<- RES($id) [ ${response.request!.method} | ${response.request!.url}]');
 
     requestLog.writeln('  * status-code: ${response.statusCode}');
 
-    if (options.logHeaders) {
-      requestLog
-          .writeln('  * headers: ${response.headers.isEmpty ? 'empty' : ''}');
+    if (options.logRequestHeaders) {
+      requestLog.writeln('  * headers: ${response.headers.isEmpty ? 'empty' : ''}');
       response.headers.forEach((k, v) {
         requestLog.writeln('    * $k: $v');
       });
     }
 
-    if (options.logContent) {
+    if (options.logResponseContent) {
       requestLog.writeln('  * content-length: ${response.contentLength}');
       final content = await response.stream.toBytes();
-      requestLog.writeln(
-          '  * content: ${utf8.decode(content, allowMalformed: true)}');
+      requestLog.writeln('  * content: ${utf8.decode(content, allowMalformed: true)}');
     }
 
     return requestLog.toString();
   }
 
-  String _formatError(int id, BaseRequest request, dynamic error,
-      StackTrace stackTrace, LogOptions options) {
+  String _formatError(int id, BaseRequest request, dynamic error, StackTrace stackTrace, LogOptions options) {
     final errorLog = StringBuffer();
     errorLog.writeln('!) ERR($id) [ ${request.method} | ${request.url} ]');
 
     if (error != null) {
-      errorLog.writeln('  * error: ${error}');
+      errorLog.writeln('  * error: $error');
     }
 
-    if (stackTrace != null) {
-      errorLog.writeln('  * stack-trace: ${stackTrace}');
-    }
+    errorLog.writeln('  * stack-trace: $stackTrace');
 
     return errorLog.toString();
   }
 
-  Future<StreamedResponse> sendWithOptions(
-      BaseRequest request, LogOptions options) async {
+  @override
+  Future<StreamedResponse> sendWithOptions(BaseRequest request, LogOptions options) async {
     if (!options.isEnabled) {
       return await super.sendWithOptions(request, options);
     }
 
     final id = _id++;
 
-    if (options.logContent) {
+    if (options.logRequestContent) {
       request = BufferedRequest(request);
     }
 
     // Logging request
     final requestLog = await _formatRequest(id, request, options);
-    this.log(requestLog, options);
+    log(requestLog, options);
 
     try {
       var response = await super.sendWithOptions(request, options);
 
-      if (options.logContent) {
+      if (options.logResponseContent) {
         response = BufferedStreamResponse(response);
       }
 
       // Logging response
-      final responsetLog = await _formatResponse(id, response, options);
-      this.log(responsetLog, options);
+      final responseLog = await _formatResponse(id, response, options);
+      log(responseLog, options);
 
       return response;
     } catch (error, stacktrace) {
-      final errorLog =
-          await _formatError(id, request, error, stacktrace, options);
-      this.log(errorLog, options);
+      final errorLog = _formatError(id, request, error, stacktrace, options);
+      log(errorLog, options);
       rethrow;
     }
   }

--- a/http_extensions_log/lib/src/options.dart
+++ b/http_extensions_log/lib/src/options.dart
@@ -7,8 +7,20 @@ class LogOptions {
   /// Indicates whether headers should be logged.
   final bool logHeaders;
 
+  /// Indicates whether sent headers should be logged (overrides [logHeaders]).
+  final bool logRequestHeaders;
+
+  /// Indicates whether received headers should be logged (overrides [logHeaders]).
+  final bool logResponseHeaders;
+
   /// Indicates whether sent body and received content should be logged.
   final bool logContent;
+
+  /// Indicates whether sent body should be logged (overrides [logContent]).
+  final bool logRequestContent;
+
+  /// Indicates whether received content should be logged (overrides [logContent]).
+  final bool logResponseContent;
 
   /// Indicates whether the logger is enabled.
   final bool isEnabled;
@@ -16,6 +28,16 @@ class LogOptions {
   const LogOptions(
       {this.level = Level.FINE,
       this.isEnabled = true,
-      this.logHeaders = true,
-      this.logContent = false});
+      bool? logHeaders,
+      bool? logRequestHeaders,
+      bool? logResponseHeaders,
+      bool? logContent,
+      bool? logRequestContent,
+      bool? logResponseContent})
+      : logRequestHeaders = logRequestHeaders ?? logHeaders ?? false,
+        logResponseHeaders = logResponseHeaders ?? logHeaders ?? false,
+        logHeaders = logHeaders ?? false,
+        logRequestContent = logRequestContent ?? logContent ?? false,
+        logResponseContent = logResponseContent ?? logContent ?? false,
+        logContent = logContent ?? false;
 }

--- a/http_extensions_retry/.gitignore
+++ b/http_extensions_retry/.gitignore
@@ -1,11 +1,28 @@
-# Files and directories created by pub
-.dart_tool/
-.packages
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
 
-# Conventional directory for build outputs
-build/
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+/out/
 
 # Directory created by dartdoc
 doc/api/
+/http_extensions_retry.iml


### PR DESCRIPTION
This allows separate logging of response/request headers/contents. Can be usefull in some cases, eg. when sending/receiving binary data which are not printable.